### PR TITLE
Pushing image to ecr on circleci builds.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,6 @@ deployment:
     commands:
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$CIRCLE_SHA1 $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:$CIRCLE_SHA1
-      - docker tag python-service:$CIRCLE_SHA1 $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//z}"
+      - docker tag python-service:$CIRCLE_SHA1 $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//_}"
       - docker push $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:$CIRCLE_SHA1
-      - docker push $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//z}"
+      - docker push $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//_}"

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ machine:
 dependencies:
   override:
     - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
-    - docker build -t python-service:$BUILD_TAG .
+    - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1 .
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,10 @@ dependencies:
     - docker info
     - docker build -t python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} .
 
+test:
+  override:
+    - echo "Successfully built new image!"
+
 deployment:
   hub:
     branch: feature/circleci
@@ -32,7 +36,3 @@ deployment:
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
-
-  test:
-    override:
-      - echo "Successfully built new image!"

--- a/circle.yml
+++ b/circle.yml
@@ -21,10 +21,6 @@ dependencies:
   override:
     - docker build -t python-service:$CIRCLE_SHA1 .
 
-test:
-  override:
-    - echo "Successfully built new image!"
-
 deployment:
   ecr:
     branch: feature/circleci
@@ -34,3 +30,7 @@ deployment:
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
+
+test:
+  override:
+    - docker pull 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -32,5 +32,5 @@ deployment:
     commands:
       - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:$BUILD_TAG 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
+      - docker tag python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ machine:
 
 dependencies:
   override:
-    - export BUILD_TAG=dino-$CIRCLE_SHA1
+    - export BUILD_TAG=dino-{CIRCLE_SHA1}
     - docker info
     - docker build -t python-service:$BUILD_TAG .
 

--- a/circle.yml
+++ b/circle.yml
@@ -28,5 +28,5 @@ deployment:
     branch: feature/circleci
     commands:
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:$BUILD_TAG 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
+      - docker tag python-service:mouse 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:mouse
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:mouse

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,31 @@
+#
+# CircleCI Configuration for publishing a Python service using AWS CodeDeploy.
+#
+#
+# - This script will require setting the $GEMFURY_REPO_URL in CircleCI,
+#    under Project Settings -> Environment Variables.
+# - Using `pip install` with --extra-index-url below allows for package dependencies
+#   using the private repository as well.
+# - We use nose for running unit-tests below using `python setup.py nosetests`
+# - See the 'codedeploy' section under 'deployment' for appropriate mappings between the different
+#   code branches (master, develop) and AWS CodeDeploy Deployment Groups / settings
+# - Make sure to include the build.sh script used below in your codebase, available here:
+#       https://gist.github.com/adamhadani/e79dcf9bf676a2f4d298
+#
+########################################################################################################
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker build -t python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1
+
+deployment:
+  hub:
+    branch: feature/circleci
+    commands:
+      - eval $(aws ecr get-login --region us-east-1)
+      - docker tag python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -17,20 +17,15 @@ machine:
   services:
     - docker
 
-dependencies:
-  override:
-    - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
-    - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1 .
-
 test:
   override:
     - echo "Successfully built new image!"
 
 deployment:
-  hub:
+  ecr:
     branch: feature/circleci
     commands:
-      - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
+      - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') python-service:$CIRCLE_SHA1 .
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
+      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,10 @@ machine:
   services:
     - docker
 
+dependencies:
+  override:
+    - docker build -t python-service:$CIRCLE_SHA1 .
+
 test:
   override:
     - echo "Successfully built new image!"
@@ -25,7 +29,6 @@ deployment:
   ecr:
     branch: feature/circleci
     commands:
-      - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') -t python-service:$CIRCLE_SHA1 .
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ machine:
 
 dependencies:
   override:
-    - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '')-$CIRCLE_SHA1
+    - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
     - docker build -t python-service:$BUILD_TAG .
 
 test:
@@ -30,7 +30,7 @@ deployment:
   hub:
     branch: feature/circleci
     commands:
-      - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '')-$CIRCLE_SHA1
+      - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$BUILD_TAG 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ machine:
 
 dependencies:
   override:
-    - export BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
+    - export BUILD_TAG=dino-$CIRCLE_SHA1
     - docker info
     - docker build -t python-service:$BUILD_TAG .
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
   override:
     - export BUILD_TAG=dino-{CIRCLE_SHA1}
     - docker info
-    - docker build -t python-service:$BUILD_TAG .
+    - docker build -t python-service:mouse .
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -19,14 +19,20 @@ machine:
 
 dependencies:
   override:
-    - export BUILD_TAG=dino-{CIRCLE_SHA1}
+    - BUILD_TAG={CIRCLE_BRANCH}-{CIRCLE_SHA1}
+    - echo $BUILD_TAG
     - docker info
-    - docker build -t python-service:mouse .
+    - docker build -t python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} .
 
 deployment:
   hub:
     branch: feature/circleci
     commands:
+      - echo $BUILD_TAG
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:mouse 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:mouse
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:mouse
+      - docker tag python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
+
+  test:
+    override:
+      - echo "Successfully built new image!"

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,10 @@ dependencies:
   override:
     - docker build -t python-service:$CIRCLE_SHA1 .
 
+test:
+  override:
+    - echo "Building python-service container!"
+
 deployment:
   ecr:
     branch: feature/circleci
@@ -30,7 +34,3 @@ deployment:
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
-
-test:
-  override:
-    - docker pull 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -19,10 +19,8 @@ machine:
 
 dependencies:
   override:
-    - BUILD_TAG={CIRCLE_BRANCH}-{CIRCLE_SHA1}
-    - echo $BUILD_TAG
-    - docker info
-    - docker build -t python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} .
+    - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '')-$CIRCLE_SHA1
+    - docker build -t python-service:$BUILD_TAG .
 
 test:
   override:
@@ -32,7 +30,7 @@ deployment:
   hub:
     branch: feature/circleci
     commands:
-      - echo $BUILD_TAG
+      - BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '')-$CIRCLE_SHA1
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1} 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:{CIRCLE_BRANCH}-{CIRCLE_SHA1}
+      - docker tag python-service:$BUILD_TAG 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -30,3 +30,4 @@ deployment:
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,13 @@
 #
-# CircleCI Configuration for publishing a Python service using AWS CodeDeploy.
+# CircleCI Configuration for publishing a base docker image for Python services to Amazon ecr.
 #
 #
-# - This script will require setting the $GEMFURY_REPO_URL in CircleCI,
-#    under Project Settings -> Environment Variables.
-# - Using `pip install` with --extra-index-url below allows for package dependencies
-#   using the private repository as well.
-# - We use nose for running unit-tests below using `python setup.py nosetests`
-# - See the 'codedeploy' section under 'deployment' for appropriate mappings between the different
-#   code branches (master, develop) and AWS CodeDeploy Deployment Groups / settings
-# - Make sure to include the build.sh script used below in your codebase, available here:
-#       https://gist.github.com/adamhadani/e79dcf9bf676a2f4d298
+# - This script requires:
+#     - CIRCLE_SHA1: the commit associated with this build (available in all circleci builds)
+#     - CIRCLE_BRANCH: the branch associated with this commit (available in all circleci builds)
+#     - ECR_INSTANCE_ID: the id of your Amazon ECR instance
+#     - ECR_DOMAIN: The domain associated with AWS ECR.
+#     - aws credentials
 #
 ########################################################################################################
 machine:
@@ -30,7 +27,7 @@ deployment:
     branch: feature/circleci
     commands:
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
-      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
+      - docker tag python-service:$CIRCLE_SHA1 $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:$CIRCLE_SHA1
+      - docker tag python-service:$CIRCLE_SHA1 $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//z}"
+      - docker push $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:$CIRCLE_SHA1
+      - docker push $ECR_INSTANCE_ID.$ECR_DOMAIN/python-service:"${CIRCLE_BRANCH/\//z}"

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker build -t python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1
+    - docker build -t python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1 .
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,6 @@ deployment:
       - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') -t python-service:$CIRCLE_SHA1 .
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
-      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH
+      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$(echo $CIRCLE_BRANCH | tr '/' '_')

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ deployment:
   ecr:
     branch: feature/circleci
     commands:
-      - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') python-service:$CIRCLE_SHA1 .
+      - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') -t python-service:$CIRCLE_SHA1 .
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1

--- a/circle.yml
+++ b/circle.yml
@@ -19,13 +19,14 @@ machine:
 
 dependencies:
   override:
+    - export BUILD_TAG=$(echo $CIRCLE_BRANCH | tr '/' '_')-$CIRCLE_SHA1
     - docker info
-    - docker build -t python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1 .
+    - docker build -t python-service:$BUILD_TAG .
 
 deployment:
   hub:
     branch: feature/circleci
     commands:
       - eval $(aws ecr get-login --region us-east-1)
-      - docker tag python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1
-      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH-$CIRCLE_SHA1
+      - docker tag python-service:$BUILD_TAG 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG
+      - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$BUILD_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -28,4 +28,5 @@ deployment:
       - docker build -t python-service:$(echo $CIRCLE_BRANCH | tr '/' '_') -t python-service:$CIRCLE_SHA1 .
       - eval $(aws ecr get-login --region us-east-1)
       - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1
+      - docker tag python-service:$CIRCLE_SHA1 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_BRANCH
       - docker push 021749107756.dkr.ecr.us-east-1.amazonaws.com/python-service:$CIRCLE_SHA1


### PR DESCRIPTION
This circle.yml file will push a new image to the registry tagged with the commit sha and the branch.

This avoids the use of the `latest` tag to prevent accidentally pulling `dev` builds into non-dev environments.