### PR TITLE
Pip install Twisted in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 RUN if [ ! -z ${PY_MAJOR} ]; then \
     update-alternatives --install /usr/bin/python python /usr/bin/python${PY_MAJOR} 1; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip${PY_MAJOR} 1; \
-    fi 
+    fi
 
 # We need a proper locale
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
@@ -33,7 +33,7 @@ ENV LC_ALL en_US.UTF-8
 
 
 # We need these libraries often enough (and they're binary), so we install them upfront
-ENV PIP_COMMON_PACKAGES alembic cffi cryptography flask MarkupSafe ndg-httpsclient psycopg2 pycrypto requests[security] SQLAlchemy SQLAlchemy-Utils PyYAML uwsgi
+ENV PIP_COMMON_PACKAGES alembic cffi cryptography flask MarkupSafe ndg-httpsclient psycopg2 pycrypto requests[security] SQLAlchemy SQLAlchemy-Utils PyYAML uwsgi twisted
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${BUILD_PACKAGES} && \
     pip install --upgrade ${PIP_COMMON_PACKAGES} && \


### PR DESCRIPTION
Why:
Twisted is required by Bravado, which in turn is required by the new [Marquez](https://github.com/globality-corp/marquez) library.
The aim is to replace the `<service>_client` written in each `<service>_daemon` to make use of Marquez auto-generated clients (based on the Swagger spec), meaning that Twisted will be needed for most services.

Addressed by:
`pip install`ing Twisted in the base Docker image