### PR TITLE
Removed redundant pycrypto dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV LC_ALL en_US.UTF-8
 
 
 # We need these libraries often enough (and they're binary), so we install them upfront
-ENV PIP_COMMON_PACKAGES alembic cffi cryptography flask MarkupSafe ndg-httpsclient psycopg2 pycrypto requests[security] SQLAlchemy SQLAlchemy-Utils PyYAML uwsgi twisted
+ENV PIP_COMMON_PACKAGES alembic cffi cryptography flask MarkupSafe ndg-httpsclient psycopg2 requests[security] SQLAlchemy SQLAlchemy-Utils PyYAML uwsgi twisted
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${BUILD_PACKAGES} && \
     pip install --upgrade ${PIP_COMMON_PACKAGES} && \


### PR DESCRIPTION
Credstash and by extension microcosm-dynamodb no longer depends on this